### PR TITLE
Added modman & composer & correct misspelling to make the module work

### DIFF
--- a/app/code/local/ES/PageSpeedCacheFlush/Block/Flush.php
+++ b/app/code/local/ES/PageSpeedCacheFlush/Block/Flush.php
@@ -10,6 +10,6 @@ class ES_PageSpeedCacheFlush_Block_Flush extends Mage_Adminhtml_Block_Template
 {
     public function getFlushWsdlCacheUrl()
     {
-        return Mage::helper('adminhtml')->getUrl('bs_page_speed_cache_flush/Flush/Index');
+        return Mage::helper('adminhtml')->getUrl('es_page_speed_cache_flush/Flush/Index');
     }
 }

--- a/app/design/adminhtml/base/default/layout/es_page_speed/admin_cache_flush.xml
+++ b/app/design/adminhtml/base/default/layout/es_page_speed/admin_cache_flush.xml
@@ -2,7 +2,7 @@
 <layout>
     <adminhtml_cache_index>
         <reference name="cache.additional">
-            <block type="bs_pagespeedcacheflush/flush" template="bs_pagespeedcacheflush/flush_button.phtml"
+            <block type="es_pagespeedcacheflush/flush" template="es_pagespeedcacheflush/flush_button.phtml"
                    name="pagespped.flush"></block>
         </reference>
     </adminhtml_cache_index>

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,16 @@
+{
+    "name": "eriksimonic/magento-page_speed_cache_flush",
+    "license": "MIT",
+    "type": "magento-module",
+    "description": "Magento - Google page speed cache flush from admin Area",
+    "homepage": "https://github.com/eriksimonic/magento-page_speed_cache_flush",
+    "require": {
+        "magento-hackathon/magento-composer-installer": "*"
+    },
+    "authors":[
+        {
+            "name":"Erik Simonič"
+        }
+    ]
+}
+

--- a/modman
+++ b/modman
@@ -1,0 +1,4 @@
+app/code/local/ES/PageSpeedCacheFlush                                           app/code/local/ES/PageSpeedCacheFlush
+app/design/adminhtml/base/default/layout/es_page_speed                          app/design/adminhtml/base/default/layout/es_page_speed
+app/design/adminhtml/base/default/template/es_pagespeedcacheflush               app/design/adminhtml/base/default/template/es_pagespeedcacheflush
+app/etc/modules/ES_PageSpeedCacheFlush.xml                                      app/etc/modules/ES_PageSpeedCacheFlush.xml


### PR DESCRIPTION
Hi,

I found that the clean cache button did not appear in the backend and I fixed it by correct some misspelling in the block and layout files.

I also added modman & composer file, so peoples can install the module via modman & composer method.

Thanks
Phu